### PR TITLE
Modernize Mroonga formula

### DIFF
--- a/mroonga.rb
+++ b/mroonga.rb
@@ -16,6 +16,9 @@ class Mroonga < Formula
   option "with-debug[=full]", "Build with debug option"
   option "with-default-parser=PARSER", "Specify the default fulltext parser like with-default-parser=TokenMecab (default: TokenBigram)"
 
+  deprecated_option "use-homebrew-mysql" => "with-homebrew-mysql"
+  deprecated_option "use-homebrew-mariadb" => "with-homebrew-mariadb"
+
   if build.with?("mecab")
     depends_on "groonga" => "--with-mecab"
   else

--- a/mroonga.rb
+++ b/mroonga.rb
@@ -13,9 +13,9 @@ class Mroonga < Formula
     depends_on "groonga"
   end
 
-  if ARGV.include?("--use-homebrew-mysql")
+  if build.with?("use-homebrew-mysql")
     depends_on "mysql"
-  elsif ARGV.include?("--use-homebrew-mariadb")
+  elsif build.with?("use-homebrew-mariadb")
     depends_on "mariadb"
   end
 
@@ -34,9 +34,9 @@ class Mroonga < Formula
   end
 
   def install
-    if ARGV.include?("--use-homebrew-mysql")
+    if build.with?("use-homebrew-mysql")
       mysql_formula_name = "mysql"
-    elsif ARGV.include?("--use-homebrew-mariadb")
+    elsif build.with?("use-homebrew-mariadb")
       mysql_formula_name = "mariadb"
     else
       mysql_formula_name = nil

--- a/mroonga.rb
+++ b/mroonga.rb
@@ -7,8 +7,8 @@ class Mroonga < Formula
   depends_on "pkg-config" => :build
   depends_on "groonga-normalizer-mysql"
 
-  option "with-homebrew-mysql", "Use MySQL installed by Homebrew."
-  option "with-homebrew-mariadb", "Use MariaDB installed by Homebrew. You can't use this option with use-homebrew-mysql."
+  option "use-homebrew-mysql", "Use MySQL installed by Homebrew."
+  option "use-homebrew-mariadb", "Use MariaDB installed by Homebrew. You can't use this option with use-homebrew-mysql."
   option "with-mecab", "Use MeCab installed by Homebrew. You can use additional tokenizer - TokenMecab. Note that you need to build Groonga with MeCab"
   option "with-mysql-source=PATH", "MySQL source directory. You can't use this option with use-homebrew-mysql and use-homebrew-mariadb"
   option "with-mysql-build=PATH", "MySQL build directory (default: guess from with-mysql-source)"
@@ -16,18 +16,15 @@ class Mroonga < Formula
   option "with-debug[=full]", "Build with debug option"
   option "with-default-parser=PARSER", "Specify the default fulltext parser like with-default-parser=TokenMecab (default: TokenBigram)"
 
-  deprecated_option "use-homebrew-mysql" => "with-homebrew-mysql"
-  deprecated_option "use-homebrew-mariadb" => "with-homebrew-mariadb"
-
   if build.with?("mecab")
     depends_on "groonga" => "--with-mecab"
   else
     depends_on "groonga"
   end
 
-  if build.with?("homebrew-mysql")
+  if build.include?("use-homebrew-mysql")
     depends_on "mysql"
-  elsif build.with?("homebrew-mariadb")
+  elsif build.include?("use-homebrew-mariadb")
     depends_on "mariadb"
   end
 
@@ -37,9 +34,9 @@ class Mroonga < Formula
   end
 
   def install
-    if build.with?("homebrew-mysql")
+    if build.include?("use-homebrew-mysql")
       mysql_formula_name = "mysql"
-    elsif build.with?("homebrew-mariadb")
+    elsif build.include?("use-homebrew-mariadb")
       mysql_formula_name = "mariadb"
     else
       mysql_formula_name = nil
@@ -55,7 +52,7 @@ class Mroonga < Formula
     else
       mysql_source_path = option_value("--with-mysql-source")
       if mysql_source_path.nil?
-        raise "--with-homebrew-mysql, --with-homebrew-mariadb or --with-mysql-source=PATH is required"
+        raise "--use-homebrew-mysql, --use-homebrew-mariadb or --with-mysql-source=PATH is required"
       end
       install_mroonga(mysql_source_path, nil)
     end

--- a/mroonga.rb
+++ b/mroonga.rb
@@ -7,20 +7,8 @@ class Mroonga < Formula
   depends_on "pkg-config" => :build
   depends_on "groonga-normalizer-mysql"
 
-  if build.with?("mecab")
-    depends_on "groonga" => "--with-mecab"
-  else
-    depends_on "groonga"
-  end
-
-  if build.with?("use-homebrew-mysql")
-    depends_on "mysql"
-  elsif build.with?("use-homebrew-mariadb")
-    depends_on "mariadb"
-  end
-
-  option "use-homebrew-mysql", "Use MySQL installed by Homebrew."
-  option "use-homebrew-mariadb", "Use MariaDB installed by Homebrew. You can't use this option with use-homebrew-mysql."
+  option "with-homebrew-mysql", "Use MySQL installed by Homebrew."
+  option "with-homebrew-mariadb", "Use MariaDB installed by Homebrew. You can't use this option with use-homebrew-mysql."
   option "with-mecab", "Use MeCab installed by Homebrew. You can use additional tokenizer - TokenMecab. Note that you need to build Groonga with MeCab"
   option "with-mysql-source=PATH", "MySQL source directory. You can't use this option with use-homebrew-mysql and use-homebrew-mariadb"
   option "with-mysql-build=PATH", "MySQL build directory (default: guess from with-mysql-source)"
@@ -28,15 +16,27 @@ class Mroonga < Formula
   option "with-debug[=full]", "Build with debug option"
   option "with-default-parser=PARSER", "Specify the default fulltext parser like with-default-parser=TokenMecab (default: TokenBigram)"
 
+  if build.with?("mecab")
+    depends_on "groonga" => "--with-mecab"
+  else
+    depends_on "groonga"
+  end
+
+  if build.with?("homebrew-mysql")
+    depends_on "mysql"
+  elsif build.with?("homebrew-mariadb")
+    depends_on "mariadb"
+  end
+
   def patches
     [
     ]
   end
 
   def install
-    if build.with?("use-homebrew-mysql")
+    if build.with?("homebrew-mysql")
       mysql_formula_name = "mysql"
-    elsif build.with?("use-homebrew-mariadb")
+    elsif build.with?("homebrew-mariadb")
       mysql_formula_name = "mariadb"
     else
       mysql_formula_name = nil

--- a/mroonga.rb
+++ b/mroonga.rb
@@ -55,7 +55,7 @@ class Mroonga < Formula
     else
       mysql_source_path = option_value("--with-mysql-source")
       if mysql_source_path.nil?
-        raise "--use-homebrew-mysql, --use-homebrew-mariadb or --with-mysql-source=PATH is required"
+        raise "--with-homebrew-mysql, --with-homebrew-mariadb or --with-mysql-source=PATH is required"
       end
       install_mroonga(mysql_source_path, nil)
     end

--- a/mroonga.rb
+++ b/mroonga.rb
@@ -19,18 +19,14 @@ class Mroonga < Formula
     depends_on "mariadb"
   end
 
-  def options
-    [
-      ["--use-homebrew-mysql", "Use MySQL installed by Homebrew."],
-      ["--use-homebrew-mariadb", "Use MariaDB installed by Homebrew. You can't use this option with --use-homebrew-mysql."],
-      ["--with-mecab", "Use MeCab installed by Homebrew. You can use additional tokenizer - TokenMecab. Note that you need to build Groonga with MeCab"],
-      ["--with-mysql-source=PATH", "MySQL source directory. You can't use this option with --use-homebrew-mysql and --use-homebrew-mariadb"],
-      ["--with-mysql-build=PATH", "MySQL build directory (default: guess from --with-mysql-source)"],
-      ["--with-mysql-config=PATH", "mysql_config path (default: guess from --with-mysql-source)"],
-      ["--with-debug[=full]", "Build with debug option"],
-      ["--with-default-parser=PARSER", "Specify the default fulltext parser like --with-default-parser=TokenMecab (default: TokenBigram)"],
-    ]
-  end
+  option "use-homebrew-mysql", "Use MySQL installed by Homebrew."
+  option "use-homebrew-mariadb", "Use MariaDB installed by Homebrew. You can't use this option with use-homebrew-mysql."
+  option "with-mecab", "Use MeCab installed by Homebrew. You can use additional tokenizer - TokenMecab. Note that you need to build Groonga with MeCab"
+  option "with-mysql-source=PATH", "MySQL source directory. You can't use this option with use-homebrew-mysql and use-homebrew-mariadb"
+  option "with-mysql-build=PATH", "MySQL build directory (default: guess from with-mysql-source)"
+  option "with-mysql-config=PATH", "mysql_config path (default: guess from with-mysql-source)"
+  option "with-debug[=full]", "Build with debug option"
+  option "with-default-parser=PARSER", "Specify the default fulltext parser like with-default-parser=TokenMecab (default: TokenBigram)"
 
   def patches
     [

--- a/mroonga.rb
+++ b/mroonga.rb
@@ -103,7 +103,7 @@ class Mroonga < Formula
   end
 
   def build_formula(name)
-    formula = Formula.factory(name)
+    formula = Formula[name]
     formula.extend(Patchable)
     formula.brew do
       yield formula

--- a/mroonga.rb
+++ b/mroonga.rb
@@ -161,8 +161,8 @@ class Mroonga < Formula
   end
 
   def option_value(search_key)
-    ARGV.options_only.each do |option|
-      key, value = option.split(/=/, 2)
+    build.used_options.each do |option|
+      key, value = option.to_s.split(/=/, 2)
       return value || true if key == search_key
     end
     nil

--- a/mroonga.rb
+++ b/mroonga.rb
@@ -62,7 +62,7 @@ class Mroonga < Formula
     end
   end
 
-  def test
+  test do
   end
 
   def caveats


### PR DESCRIPTION
そのままmasterに入れて良いか判断つかなかったのでpull requestにします。

## 要約

* brew audit で出力されるErrorを可能な限り減らしました。
* より現在のHomebrewにふさわしいとされる記法を用いるようにしました。

## 詳細

### このPull Requestの動機

```bash
$ brew audit mroonga
```

を行うと以下のようなErrorが出るようになっていました。

```log
mroonga/mroonga/mroonga:
 * "Formula.factory(name)" is deprecated in favor of "Formula[name]"
 * Use build instead of ARGV to check options
 * Use build instead of ARGV to check options
 * Use new-style option definitions
 * Use build instead of ARGV to check options
 * Use build instead of ARGV to check options
 * Use new-style test definitions (test do)
 * Use build instead of ARGV to check options

Error: 8 problems in 1 formula
```

### Pull Request の作業内容

#### 変更点

* `ARGV.include?` ではなく <s>`build.with?`</s> `build.include?` を使うようにしました
* 新しいスタイルの `option` 記法を使うようにしました
  * <s>合わせて `--use-xxx` のスタイルのオプションを `---with-xxx` に変更しました。</s>
* testの記法を`def test ... end` から新記法の `test do ... end` に変更しました。
* "Formula.factory(name)" から"Formula[name]"に置き換えました。

#### 未解決

最後のエラー ` * Use build instead of ARGV to check options` は [option_value](https://github.com/mroonga/homebrew-mroonga/blob/07c1a740600371da8deadd74341334b0b031c076/mroonga.rb#L166) で使われているため解消する方法が思いつきませんでした…。

#### 動作確認

* --use-homebrew-mariadb
* --use-homebrew-mysql

上の二つに加えて以下も足した

* --with-mecab

のオプションでMroongaが正常にインストール出来るのを確認しました。