### PR TITLE
Use "<<~EOS" instead of "<<-EOS.undent"

### DIFF
--- a/mroonga.rb
+++ b/mroonga.rb
@@ -76,7 +76,7 @@ class Mroonga < Formula
   end
 
   def caveats
-    <<-EOS.undent
+    <<~EOS
       To confirm successfuly installed, run the following command
       and confirm that 'Mroonga' is in the list:
 


### PR DESCRIPTION
ヒアドキュメントに `<<~EOS` を使うようにしました。Homebrew/brew#3319 よりスタイルが変わったようです。2018-04-30に `brew upgrade` を行った際に、以下のエラーメッセージが表示されたため、修正しました。

```
Error: Calling <<-EOS.undent is disabled!
Use <<~EOS instead.
/usr/local/Homebrew/Library/Taps/mroonga/homebrew-mroonga/mroonga.rb:97:in `caveats'
Please report this to the mroonga/mroonga tap!
Or, even better, submit a PR to fix it!
```